### PR TITLE
Fixed URL in readme and added info on aliasing "gw"

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ location to the prefix in which you want to install gdub.
 
 For example, to install gdub into `/usr/local`:
 
-    $ git clone https://github.com/ReadyTalk/gdub.git
+    $ git clone https://github.com/dougborg/gdub.git
     $ cd gdub
     $ ./install /usr/local
 


### PR DESCRIPTION
The gdub repo URL in the README.md was pointing to an old fork of the same project. I changed it to the current URL.

Also I added information on how one could create a `gradle` alias of `gw` in BASH. I like to just type `gradle` so that I don't have to retrain my muscle memory.
The section is basically the same information as I wrote for my recently discontinued ;-) [gradle-wrapper-wrapper](https://github.com/mattgruter/gradle-wrapper-wrapper) project.
