### PR TITLE
Fixing error when executing gw

### DIFF
--- a/bin/gw
+++ b/bin/gw
@@ -54,7 +54,7 @@ select_gradle() {
 execute_gradle() {
   local build_gradle=$(lookup "${GRADLE_BUILDFILE}")
   local gradle=$(select_gradle "${working_dir}")
-  local build_args=( "${BUILD_ARG}" "$@" )
+  local build_args=( ${BUILD_ARG} "$@" )
 
   if [[ -n "${build_gradle}" ]]; then
     # We got a good build file, start gradlew there.


### PR DESCRIPTION
After installing the latest version of gw it stopped working and started giving the following error.

Task '' not found in root project 'blah'

Removing the quotes fixed the issue for us, but I am unsure if it will cause problems for other users.
