### PR TITLE
support gradle buildfile named after the directory

### DIFF
--- a/bin/gw
+++ b/bin/gw
@@ -17,8 +17,12 @@ lookup() {
 
   # Search recursively upwards for file.
   until [[ "${curr_path}" == "/" ]]; do
+    local curr_base=$(basename "${curr_path}")
     if [[ -e "${curr_path}/${file}" ]]; then
       echo "${curr_path}/${file}"
+      break
+    elif [[ "${file}" == "${GRADLE_BUILDFILE}" && -e "${curr_path}/${curr_base}.gradle" ]]; then
+      echo "${curr_path}/${curr_base}.gradle"
       break
     else
       curr_path=$(dirname "${curr_path}")


### PR DESCRIPTION
This is really dirty and not likely suitable for inclusion as is, but in our builds we typically include in the settings.gradle this block:

```groovy
def setBuildFile(project) {
  project.buildFileName = "${project.name}.gradle"
  project.children.each {
    setBuildFile(it)
  }
}

rootProject.children.each {
  setBuildFile it
}
```

The nice (IMO at least) side-effect of which is that we now don't build.gradle files anywhere but the root of the project, all the other build file names match the project name (which we also match to the sub-project directory names).

This change is a dirty workaround to look for a .gradle build file that matches the name of the current directory while traversing up the path.

If there is any interest in supporting this I could look at making this somewhat less opinionated than it currently is..
